### PR TITLE
Fix the crash with the iOS SDK 8.3

### DIFF
--- a/GMAutolayout.podspec
+++ b/GMAutolayout.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "GMAutolayout"
-  s.version          = "0.1.2"
+  s.version          = "0.1.3"
   s.summary          = "Category on UIView to ease your life with AutoLayout constraints"
   s.homepage         = "https://github.com/keradgames/GMAutolayout"
   s.license          = 'MIT'

--- a/Pod/Classes/UIView+GMAutolayoutAdditions.m
+++ b/Pod/Classes/UIView+GMAutolayoutAdditions.m
@@ -232,24 +232,30 @@ CGFloat const GMAutolayoutStandardFixedViewToSuperviewSpace = 20.0f;
 
 - (void)centerXInSuperview
 {
-    [self.superview addConstraint:[NSLayoutConstraint constraintWithItem:self
-                                                               attribute:NSLayoutAttributeCenterX
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self.superview
-                                                               attribute:NSLayoutAttributeCenterX
-                                                              multiplier:1.0f
-                                                                constant:0.0f]];
+    if (self.superview)
+    {
+        [self.superview addConstraint:[NSLayoutConstraint constraintWithItem:self
+                                                                   attribute:NSLayoutAttributeCenterX
+                                                                   relatedBy:NSLayoutRelationEqual
+                                                                      toItem:self.superview
+                                                                   attribute:NSLayoutAttributeCenterX
+                                                                  multiplier:1.0f
+                                                                    constant:0.0f]];
+    }
 }
 
 - (void)centerYInSuperview
 {
-    [self.superview addConstraint:[NSLayoutConstraint constraintWithItem:self
-                                                               attribute:NSLayoutAttributeCenterY
-                                                               relatedBy:NSLayoutRelationEqual
-                                                                  toItem:self.superview
-                                                               attribute:NSLayoutAttributeCenterY
-                                                              multiplier:1.0f
-                                                                constant:0.0f]];
+    if (self.superview)
+    {
+        [self.superview addConstraint:[NSLayoutConstraint constraintWithItem:self
+                                                                   attribute:NSLayoutAttributeCenterY
+                                                                   relatedBy:NSLayoutRelationEqual
+                                                                      toItem:self.superview
+                                                                   attribute:NSLayoutAttributeCenterY
+                                                                  multiplier:1.0f
+                                                                    constant:0.0f]];
+    }
 }
 
 - (void)centerViewGroup:(NSArray *)views


### PR DESCRIPTION
I'm having this error when I launch the app with the new SDK 8.3

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', 
reason: '*** +[NSLayoutConstraint 
constraintWithItem:attribute:relatedBy:toItem:attribute:multiplier:constant:]: A 
multiplier of 0 or a nil second item together with a location for the first attribute creates 
an illegal constraint of a location equal to a constant. Location attributes must be 
specified in pairs'
```

The problem seems to be caused by the fact that the relationship of `self.superview` had not been created at the time of adding the constraint.
